### PR TITLE
Safari Extension Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@
   - Dev Tool: Navigate to `about:debugging` and click `This Firefox` then `Inspect` to open the developer tools for the extension
 - Run `npx web-ext run -t chromium` to start the extension in a new Chromium instance
   - Dev Tool: Navigate to `chrome://extensions` and toggle `Developer mode` then click `Inspect views: background page` to open the developer tools for the extension
+
+## Safari Developoment setup
+- from the project directory, run `xcrun /Applications/Xcode.app/Contents/Developer/usr/bin/safari-web-extension-converter [PATH TO EXTENSION DIRECTORY]`. This will create a build folder in your project directory and open Xcode.
+- From Xcode (NOT YOUR USUAL IDE), delete the build folder that was created in the step above. Then `run` the project as a `macos` application. This will build the extension for you and give you a pop-up saying to quit and open Safari preferences.
+  - NOTE: You must have `Developer` turn on and allow unsigned extensions to be run. Allowing unsigned extensions must be enabled every time you start a new Safari window.
+- Enable the extension and begin testing/debugging.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Ecommerse Scam Detector",
     "version": "1.0",
-    "description": "An extension that tries to deted if a website is a scam or not",
+    "description": "An extension that tries to detect if a website is a scam or not",
     "background": {
         "scripts": [
             "./node_modules/webextension-polyfill/dist/browser-polyfill.js",
@@ -14,7 +14,8 @@
         "tabs"
     ],
     "host_permissions":[
-        "https://*/*"
+        "https://*/*",
+        "http://*/*"
     ]
     ,
     "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version": 2,
     "name": "Ecommerse Scam Detector",
     "version": "1.0",
+    "description": "An extension that tries to deted if a website is a scam or not",
     "background": {
         "scripts": [
             "./node_modules/webextension-polyfill/dist/browser-polyfill.js",
@@ -12,6 +13,10 @@
         "webNavigation",
         "tabs"
     ],
+    "host_permissions":[
+        "https://*/*"
+    ]
+    ,
     "icons": {
         "38": "/icons/red-circle.png"
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A ecommerce-scam-detector",
   "main": "background.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "safari-build": "xcrun safari-web-extension-converter ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Relevant Story
[Research Safari Build#8](https://github.com/MSU-CS4360-WhiteHat/ecommerce-scam-detector/issues/8)

## Description 
Had to add `description` and `host_permissions` to `manifest.json` as they are required for safari extensions.

## Tests

Full list of [Restrictions](https://developer.apple.com/documentation/safariservices/safari_web_extensions/converting_a_web_extension_for_safari) we will need to be aware of. Most important at this stage of development: 

1. tabs
   - Extension must have host permission.
2. webNavigation
   - onCreatedNavigationTarget, onReferenceFragmentUpdated, onTabReplaced, onHistoryStateUpdated not supported. transitionType, transitionQualifiers not supported.

## Screenshots
![Screen Shot 2023-02-07 at 5 48 59 PM](https://user-images.githubusercontent.com/55564640/217401757-fceb7f6a-9d34-4952-b748-24d312ca41ec.png)
![Screen Shot 2023-02-07 at 5 48 48 PM](https://user-images.githubusercontent.com/55564640/217401765-50f0b4d2-a41a-4624-83ff-94a80b75c1d1.png)
